### PR TITLE
Adding ForAdditionalValues() for...additional values support.

### DIFF
--- a/src/app/Sieve.NET.Core/Sieves/EqualitySieve.cs
+++ b/src/app/Sieve.NET.Core/Sieves/EqualitySieve.cs
@@ -80,10 +80,20 @@ namespace Sieve.NET.Core.Sieves
 
         private List<string> ParseListOfPotentiallyAcceptableItems(IEnumerable<string> separators)
         {
-            
-            if (string.IsNullOrWhiteSpace(_potentiallyAcceptableValuesToParse)) { return new List<string>();}
+            var result = new List<string>();
+            foreach (var parseValueItem in _potentiallyAcceptableValuesToParse)
+            {
+                result.AddRange(GetParsedValuesFromPotentiallyAcceptableParseString(parseValueItem, separators));
+            }
 
-            return _potentiallyAcceptableValuesToParse.Split(separators.ToArray(), StringSplitOptions.RemoveEmptyEntries)
+            return result;
+        }
+
+        private List<string> GetParsedValuesFromPotentiallyAcceptableParseString(string parseValueItem, IEnumerable<string> separators)
+        {
+            if (string.IsNullOrWhiteSpace(parseValueItem)) { return new List<string>(); }
+
+            return parseValueItem.Split(separators.ToArray(), StringSplitOptions.RemoveEmptyEntries)
                     .Where(x => !string.IsNullOrWhiteSpace(x))
                     .ToList();
         }
@@ -110,7 +120,7 @@ namespace Sieve.NET.Core.Sieves
         public readonly IEnumerable<string> DefaultSeparators = new List<string> {",", "|"};
 
         private List<string> _potentiallyAcceptableValues = new List<string>();
-        private string _potentiallyAcceptableValuesToParse = string.Empty;
+        private List<string> _potentiallyAcceptableValuesToParse = new List<string>();
 
         /// <summary>
         /// 
@@ -255,7 +265,7 @@ namespace Sieve.NET.Core.Sieves
         }
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForValues(string valuesListToParse)
         {
-            _potentiallyAcceptableValuesToParse = valuesListToParse;
+            _potentiallyAcceptableValuesToParse.Add(valuesListToParse);
 
             return this;
         }
@@ -311,7 +321,7 @@ namespace Sieve.NET.Core.Sieves
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForAdditionalValues(string listOfValues)
         {
-            _potentiallyAcceptableValuesToParse = listOfValues;
+            _potentiallyAcceptableValuesToParse.Add(listOfValues);
             return this;
         }
     }

--- a/src/test/Sieve.NET.Core.Tests/EqualitySieveTests.cs
+++ b/src/test/Sieve.NET.Core.Tests/EqualitySieveTests.cs
@@ -424,7 +424,18 @@ namespace Sieve.NET.Core.Tests
                 [Fact]
                 public void WhenValueListExists_AddsAdditionalValueList()
                 {
-                    throw new NotImplementedException();
+                    var listOfValues = new List<int> { 1, 2, 3 };
+                    var additionalValues = new List<int> { 4, 5, 6 };
+
+                    var fullList = listOfValues.ToList().Union(additionalValues);
+
+                    var sut = new EqualitySieve<ABusinessObject>()
+                        .ForProperty(x => x.AnInt)
+                        .ForValues("1, 2, 3")
+                        .ForAdditionalValues("4, 5, 6");
+
+                    sut.AcceptableValues.Should().BeEquivalentTo(fullList);
+
                 }
             }
         }


### PR DESCRIPTION
This resolves #31.

With this change, we add an additional method: `ForAdditionalValues()`.

This method, which can be used with `IEnumerable<TPropertyType>` (e.g. IEnumerable<int> if the property type is int) or `IEnumerable<string>`, adds additional values to parse.

So, the following now works:

```
// both of the below create equality filters for the numbers 1-6
var example1 = new EqualityFilter<ABusinessObject>()
    .ForProperty(x=>x.AnInt)
    .ForValues(new List<int>{1,2,3})
    .ForAdditionalValues(new List<int>{4,5,6});

var example2 = new EqualityFilter<ABusinessObject>()
    .ForProperty(x=>x.AnInt)
    .ForValues("1,2,3")
    .ForAdditionalValues("4,5,6");
```
