### PR TITLE
ForAdditionalValues now accepts IEnumerable<string>

### DIFF
--- a/src/app/Sieve.NET.Core/Sieves/EqualitySieve.cs
+++ b/src/app/Sieve.NET.Core/Sieves/EqualitySieve.cs
@@ -11,12 +11,12 @@ namespace Sieve.NET.Core.Sieves
     using Sieve.NET.Core.Exceptions;
     using Sieve.NET.Core.Options;
 
-    public class EqualitySieve<TTypeOfOjectToFilter>
+    public class EqualitySieve<TTypeOfObjectToFilter>
     {
-        public EqualitySieve<TTypeOfOjectToFilter, TPropertyType> ForProperty<TPropertyType>(
-            Expression<Func<TTypeOfOjectToFilter, TPropertyType>> propertyExpression)
+        public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForProperty<TPropertyType>(
+            Expression<Func<TTypeOfObjectToFilter, TPropertyType>> propertyExpression)
         {
-            return new EqualitySieve<TTypeOfOjectToFilter, TPropertyType>().ForProperty(propertyExpression);
+            return new EqualitySieve<TTypeOfObjectToFilter, TPropertyType>().ForProperty(propertyExpression);
         }
     }
 
@@ -32,7 +32,7 @@ namespace Sieve.NET.Core.Sieves
             }
         }
 
-        private List<TPropertyType> _knownAcceptableValues = new List<TPropertyType>();
+        private List<TPropertyType> knownAcceptableValues = new List<TPropertyType>();
 
         private ICollection<TPropertyType> GetAcceptableValues()
         {
@@ -50,9 +50,9 @@ namespace Sieve.NET.Core.Sieves
         private ICollection<TPropertyType> ParsePotentiallyAcceptableValues()
         {
             var result = new List<TPropertyType>();
-            result.AddRange(_knownAcceptableValues);
+            result.AddRange(this.knownAcceptableValues);
 
-            foreach (var stringItem in _potentiallyAcceptableValues)
+            foreach (var stringItem in this.potentiallyAcceptableValues)
             {
                 try
                 {
@@ -75,21 +75,22 @@ namespace Sieve.NET.Core.Sieves
 
         private void AddParsedItemsToPotentiallyAcceptableValues(List<string> parsedItems)
         {
-            parsedItems.ForEach(x => _potentiallyAcceptableValues.Add(x));
+            parsedItems.ForEach(x => this.potentiallyAcceptableValues.Add(x));
         }
 
         private List<string> ParseListOfPotentiallyAcceptableItems(IEnumerable<string> separators)
         {
             var result = new List<string>();
-            foreach (var parseValueItem in _potentiallyAcceptableValuesToParse)
+            foreach (var parseValueItem in this.potentiallyAcceptableValuesToParse)
             {
+                // ReSharper disable once PossibleMultipleEnumeration -- covered by tests and works fine.
                 result.AddRange(GetParsedValuesFromPotentiallyAcceptableParseString(parseValueItem, separators));
             }
 
             return result;
         }
 
-        private List<string> GetParsedValuesFromPotentiallyAcceptableParseString(string parseValueItem, IEnumerable<string> separators)
+        private IEnumerable<string> GetParsedValuesFromPotentiallyAcceptableParseString(string parseValueItem, IEnumerable<string> separators)
         {
             if (string.IsNullOrWhiteSpace(parseValueItem)) { return new List<string>(); }
 
@@ -119,8 +120,8 @@ namespace Sieve.NET.Core.Sieves
         // ReSharper disable once MemberCanBePrivate.Global -- this is public on purpose so that folks can reference it if they need to.
         public readonly IEnumerable<string> DefaultSeparators = new List<string> {",", "|"};
 
-        private List<string> _potentiallyAcceptableValues = new List<string>();
-        private List<string> _potentiallyAcceptableValuesToParse = new List<string>();
+        private List<string> potentiallyAcceptableValues = new List<string>();
+        private List<string> potentiallyAcceptableValuesToParse = new List<string>();
 
         /// <summary>
         /// 
@@ -172,14 +173,14 @@ namespace Sieve.NET.Core.Sieves
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForValue(TPropertyType acceptableValue)
         {
             this.ClearPotentialValuesLists();
-            _knownAcceptableValues = new List<TPropertyType> {acceptableValue};
+            this.knownAcceptableValues = new List<TPropertyType> {acceptableValue};
             return this;
         }
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForValue(string stringValue)
         {
             this.ClearPotentialValuesLists();
-            _potentiallyAcceptableValues = new List<string>{stringValue};
+            this.potentiallyAcceptableValues = new List<string>{stringValue};
             return this;
         }
 
@@ -262,16 +263,16 @@ namespace Sieve.NET.Core.Sieves
             ClearPotentialValuesLists();
             List<TPropertyType> acceptableValuesList = acceptableValues.ToList();
 
-            acceptableValuesList.ForEach(x=> _knownAcceptableValues.Add(x));
+            acceptableValuesList.ForEach(x=> this.knownAcceptableValues.Add(x));
 
             return this;
         }
 
         private void ClearPotentialValuesLists()
         {
-            _knownAcceptableValues = new List<TPropertyType>();
-            _potentiallyAcceptableValues = new List<string>();
-            _potentiallyAcceptableValuesToParse = new List<string>();
+            this.knownAcceptableValues = new List<TPropertyType>();
+            this.potentiallyAcceptableValues = new List<string>();
+            this.potentiallyAcceptableValuesToParse = new List<string>();
         }
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForValues(IEnumerable<string> acceptableValues)
@@ -279,7 +280,7 @@ namespace Sieve.NET.Core.Sieves
             this.ClearPotentialValuesLists();
             var acceptableValuesList = acceptableValues.ToList();
 
-            _potentiallyAcceptableValues.AddRange(acceptableValuesList.Where(x=>!string.IsNullOrWhiteSpace(x)));
+            this.potentiallyAcceptableValues.AddRange(acceptableValuesList.Where(x=>!string.IsNullOrWhiteSpace(x)));
 
             return this;
         }
@@ -287,7 +288,7 @@ namespace Sieve.NET.Core.Sieves
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForValues(string valuesListToParse)
         {
             this.ClearPotentialValuesLists();
-            _potentiallyAcceptableValuesToParse.Add(valuesListToParse);
+            this.potentiallyAcceptableValuesToParse.Add(valuesListToParse);
 
             return this;
         }
@@ -325,19 +326,19 @@ namespace Sieve.NET.Core.Sieves
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForAdditionalValue(TPropertyType additionalValue)
         {
-            _knownAcceptableValues.Add(additionalValue);
+            this.knownAcceptableValues.Add(additionalValue);
             return this;
         }
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForAdditionalValue(string additionalValue)
         {
-            _potentiallyAcceptableValues.Add(additionalValue);
+            this.potentiallyAcceptableValues.Add(additionalValue);
             return this;
         }
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForAdditionalValues(IEnumerable<TPropertyType> listOfValues)
         {
-            _knownAcceptableValues.AddRange(listOfValues);
+            this.knownAcceptableValues.AddRange(listOfValues);
             return this;
         }
 
@@ -345,7 +346,7 @@ namespace Sieve.NET.Core.Sieves
         {
             var acceptableValuesList = acceptableValues.ToList();
 
-            _potentiallyAcceptableValues.AddRange(acceptableValuesList.Where(x => !string.IsNullOrWhiteSpace(x)));
+            this.potentiallyAcceptableValues.AddRange(acceptableValuesList.Where(x => !string.IsNullOrWhiteSpace(x)));
 
             return this;
 
@@ -353,7 +354,7 @@ namespace Sieve.NET.Core.Sieves
 
         public EqualitySieve<TTypeOfObjectToFilter, TPropertyType> ForAdditionalValues(string listOfValues)
         {
-            _potentiallyAcceptableValuesToParse.Add(listOfValues);
+            this.potentiallyAcceptableValuesToParse.Add(listOfValues);
             return this;
         }
 

--- a/src/test/Sieve.NET.Core.Tests/EqualitySieveTests.cs
+++ b/src/test/Sieve.NET.Core.Tests/EqualitySieveTests.cs
@@ -110,14 +110,12 @@ namespace Sieve.NET.Core.Tests
         {
 
             [Fact]
-            public void ForValue_DoesntDoAnythingAtFirst()
+            public void ForValue_DoesNotDoAnythingAtFirst()
             {
-                Action act =
-                    () =>
-                        new EqualitySieve<ABusinessObject>().ForProperty(x => x.AnInt)
-                            .WithInvalidValueBehavior(InvalidValueBehavior.ThrowInvalidSieveValueException)
-                            .ForValue("3abc");
-
+                Action act = () => new EqualitySieve<ABusinessObject>().ForProperty(x => x.AnInt)
+                                       .WithInvalidValueBehavior(InvalidValueBehavior.ThrowInvalidSieveValueException)
+                                       .ForValue("3abc");
+                        
                 act.ShouldNotThrow<InvalidSieveValueException>(); // shouldn't throw because we don't care about it yet.
             }
 
@@ -381,7 +379,7 @@ namespace Sieve.NET.Core.Tests
                 sut.AcceptableValues.ShouldBeEquivalentTo(expected);
             }
 
-            public class TPropertyTypeTests
+            public class PropertyTypeTests
             {
                 [Fact]
                 public void DoesNotAddDuplicateValues()
@@ -641,7 +639,7 @@ namespace Sieve.NET.Core.Tests
                 }
             }
 
-            public class TPropertyTypeTests
+            public class PropertyTypeTests
             {
                 [Fact]
                 public void DoesNotAddDuplicateValues()
@@ -946,7 +944,7 @@ namespace Sieve.NET.Core.Tests
                 [Fact]
                 public void ClearsOtherPotentialValues()
                 {
-                    var expected = new List<int>() { 5, 6 };
+                    var expected = new List<int> { 5, 6 };
                     var sut =
                         new EqualitySieve<ABusinessObject>()
                         .ForProperty(x => x.AnInt)
@@ -1098,7 +1096,7 @@ namespace Sieve.NET.Core.Tests
                 [Fact]
                 public void ClearsOtherPotentialValues()
                 {
-                    var expected = new List<int>() { 5, 6 };
+                    var expected = new List<int> { 5, 6 };
                     var sut =
                         new EqualitySieve<ABusinessObject>()
                         .ForProperty(x => x.AnInt)
@@ -1168,7 +1166,7 @@ namespace Sieve.NET.Core.Tests
             [InlineData(null)]
             [InlineData("")]
             [InlineData("    ")]
-            public void GivenEmptySeparator_DoesntChangeSeparator(string separatorToTry)
+            public void GivenEmptySeparator_DoesNotChangeSeparator(string separatorToTry)
             {
                 var sut = new EqualitySieve<ABusinessObject>().ForProperty(x => x.AnInt);
 
@@ -1205,7 +1203,7 @@ namespace Sieve.NET.Core.Tests
             }
 
             [Fact]
-            public void GivenNullList_DoesntChangeSeparator()
+            public void GivenNullList_DoesNotChangeSeparator()
             {
                 var sut = new EqualitySieve<ABusinessObject>().ForProperty(x => x.AnInt);
 
@@ -1217,7 +1215,7 @@ namespace Sieve.NET.Core.Tests
             }
 
             [Fact]
-            public void GivenEmptyList_DoesntChangeSeparator()
+            public void GivenEmptyList_DoesNotChangeSeparator()
             {
                 var sut = new EqualitySieve<ABusinessObject>().ForProperty(x => x.AnInt);
 
@@ -1258,7 +1256,7 @@ namespace Sieve.NET.Core.Tests
             }
 
             [Fact]
-            public void WithLetNoneThroughOption_DoesntAllowAnyThrough()
+            public void WithLetNoneThroughOption_DoesNotAllowAnyThrough()
             {
                 //no values defined
                 var sut =


### PR DESCRIPTION
This resolves #38.

An example unit test to demonstrate functionality:

```
var stringValuesToTry = new List<string> { "1", "3" };
var valuesToTry = new List<int> { 1, 3 };

var sut = new EqualitySieve<ABusinessObject>().ForProperty(x => x.AnInt)
    .ForAdditionalValues(stringValuesToTry);

sut.AcceptableValues.Should().BeEquivalentTo(valuesToTry);

var compiled = sut.ToCompiledExpression();
compiled.Invoke(ABusinessObjectWithAnIntOf1).Should().BeTrue();
compiled.Invoke(ABusinessObjectWithAnIntOf2).Should().BeFalse();
compiled.Invoke(ABusinessObjectWithAnIntOf3).Should().BeTrue();
```
